### PR TITLE
conda-lock 1.4.0, remove gitpython, update docs, add maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mariusvniekerk @ocefpaf
+* @bollwyvl @mariusvniekerk @ocefpaf

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Summary: Lightweight lockfile for conda environments
 
 Development: https://github.com/conda-incubator/conda-lock
 
-Documentation: https://github.com/conda-incubator/conda-lock/blob/master/README.md
+Documentation: https://conda-incubator.github.io/conda-lock
 
 Conda lock is a lightweight library that can be used to generate fully
 reproducible lock files for conda environments.
@@ -156,6 +156,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@bollwyvl](https://github.com/bollwyvl/)
 * [@mariusvniekerk](https://github.com/mariusvniekerk/)
 * [@ocefpaf](https://github.com/ocefpaf/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/conda_lock-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/c/conda-lock/conda_lock-{{ version }}.tar.gz
   sha256: 55c115a852e63395db8a6a90cf2892aab0543959f2d0bafb83158b6863831b8a
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,12 @@
-{% set name = "conda-lock" %}
-{% set version = "1.3.0" %}
+{% set version = "1.4.0" %}
 
 package:
-  name: {{ name|lower }}
+  name: conda-lock
   version: {{ version }}
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/conda_lock-{{ version }}.tar.gz
-  sha256: 8cf4b3a4e6037dadd74cc2b5325e2e76e0a42f3da31b5fd657a8030bce74ee06
+  sha256: 55c115a852e63395db8a6a90cf2892aab0543959f2d0bafb83158b6863831b8a
 
 build:
   number: 0
@@ -36,7 +35,6 @@ requirements:
     - clikit >=0.6.2
     - crashtest >=0.3.0
     - ensureconda >=1.3
-    - gitpython
     - html5lib >=1.0
     - importlib-metadata >=1.7.0
     - jinja2
@@ -62,7 +60,7 @@ test:
     - pip
 
 about:
-  home: https://github.com/conda-incubator/{{ name }}
+  home: https://github.com/conda-incubator/conda-lock
   license: MIT
   license_family: MIT
   license_file: LICENSE
@@ -75,8 +73,8 @@ about:
     This also has the added benefit of acting as an external presolve for conda
     as the lockfiles it generates results in the conda solver not being invoked
     when installing the packages from the generated lockfile.
-  doc_url: https://github.com/conda-incubator/conda-lock/blob/master/README.md
-  dev_url: https://github.com/conda-incubator/{{ name }}
+  doc_url: https://conda-incubator.github.io/conda-lock
+  dev_url: https://github.com/conda-incubator/conda-lock
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -80,3 +80,4 @@ extra:
   recipe-maintainers:
     - mariusvniekerk
     - ocefpaf
+    - bollwyvl


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Notes:
- removes `gitpython` (has CVEs)
- update docs url
- clean up jinja vars
- add maintainer :wave: