### PR TITLE
Changed doc_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
 About conda-lock
 ================
 
-Home: https://github.com/conda-incubator/conda-lock
+Home: https://github.com/conda/conda-lock
 
 Package license: MIT
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/conda-lock-feedstock/blob/main/LICENSE.txt)
 
 Summary: Lightweight lockfile for conda environments
-
-Development: https://github.com/conda-incubator/conda-lock
 
 Documentation: https://conda.github.io/conda-lock/
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Summary: Lightweight lockfile for conda environments
 
 Development: https://github.com/conda-incubator/conda-lock
 
-Documentation: https://conda-incubator.github.io/conda-lock
+Documentation: https://conda.github.io/conda-lock/
 
 Conda lock is a lightweight library that can be used to generate fully
 reproducible lock files for conda environments.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 55c115a852e63395db8a6a90cf2892aab0543959f2d0bafb83158b6863831b8a
 
 build:
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . -vv
   noarch: python
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,7 @@ test:
     - pip
 
 about:
-  home: https://github.com/conda-incubator/conda-lock
+  home: https://github.com/conda/conda-lock
   license: MIT
   license_family: MIT
   license_file: LICENSE
@@ -72,7 +72,6 @@ about:
     as the lockfiles it generates results in the conda solver not being invoked
     when installing the packages from the generated lockfile.
   doc_url: https://conda.github.io/conda-lock/ 
-  dev_url: https://github.com/conda-incubator/conda-lock
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,7 +71,7 @@ about:
     This also has the added benefit of acting as an external presolve for conda
     as the lockfiles it generates results in the conda solver not being invoked
     when installing the packages from the generated lockfile.
-  doc_url: https://conda-incubator.github.io/conda-lock
+  doc_url: https://conda.github.io/conda-lock/ 
   dev_url: https://github.com/conda-incubator/conda-lock
 
 extra:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
The previous doc_url returned a 404 when browsing to the docmentation, I've updated it with what I think is the correct URL. At [Prefix.dev conda-lock](https://prefix.dev/channels/conda-forge/packages/conda-lock) we use this to show the different url's on the page. That's how I found out :)

<!--
Please add any other relevant info below:
-->
